### PR TITLE
Fix slice pointer map bug on hook usage

### DIFF
--- a/map.go
+++ b/map.go
@@ -182,6 +182,10 @@ func (d *Decoder) nested(val reflect.Value) interface{} {
 		// TODO(arslan): should this be optional?
 		finalVal = val.Interface()
 	case reflect.Slice, reflect.Array:
+		if val.Type().Kind() == reflect.Ptr {
+			val = val.Elem()
+		}
+
 		if val.Type().Kind() == reflect.Interface {
 			finalVal = val.Interface()
 


### PR DESCRIPTION
The hook function(s) does not check the pointer of slices.

Example,

https://go.dev/play/p/kNtNUeYGSAO

Expected,

```
output: map[string]interface {}{"created_at":1257894000, "user":map[string]interface {}{"created_at":1257894000, "id":1, "name":"User 1"}, "users":[]interface {}{map[string]interface {}{"created_at":1257894000, "id":1, "name":"User 1"}}}
```

Got,

```
output: map[string]interface {}{"created_at":1257894000, "user":map[string]interface {}{"created_at":1257894000, "id":1, "name":"User 1"}, "users":(*[]main.User)(0xc000010060)}
```
