### PR TITLE
More Decoder options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ go get github.com/worldline-go/struct2
 
 Get decoder and run `Map` method, default looking the `struct` tag in struct.
 
-Supported tags: `-`, `omitempty`, `string`, `ptr2`, `omitnested`, `flatten`.
+Supported tags: `-`, `omitempty`, `string`, `ptr2`, `omitnested`, `flatten`, `remain`.
 
 Convertion order is __`-`, `omitempty`, `string`, `ptr2`, custom hook function, hooker interface, `omitnested` + `flatten`__
 
@@ -59,8 +59,10 @@ Check documentation examples.
 
 __omitnested__: very helpful to don't want to touch data.
 
-__ptr2__: convert pointer to the concrete value, if pointer is nil new value generating.
+__ptr2__: convert pointer to the concrete value. If pointer is nil, new empty value is generated.
 ptr2 to effect custom hook functions and hooker interface also omitnested.
+
+__remain__: Must be defined as `map[string]interface{}` in struct. Puts all unknown fields, destined for the struct into the `remain` field.
 
 ### Decode
 

--- a/decode.go
+++ b/decode.go
@@ -532,6 +532,10 @@ func (d *Decoder) decodeMapFromStruct(name string, dataVal, val, valMap reflect.
 		tagValue, selectedTagName := d.getTagValue(f)
 		keyName := f.Name
 
+		if d.OuputCamelCase {
+			keyName = strings.ToLower(keyName[0:1]) + keyName[1:]
+		}
+
 		if tagValue == "" && d.IgnoreUntaggedFields {
 			continue
 		}

--- a/decode.go
+++ b/decode.go
@@ -1023,16 +1023,20 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 
 	// If we have a "remain"-tagged field and we have unused keys then
 	// we put the unused keys directly into the remain field.
-	if remainField != nil && len(dataValKeysUnused) > 0 {
-		// Build a map of only the unused values
-		remain := map[interface{}]interface{}{}
-		for key := range dataValKeysUnused {
-			remain[key] = dataVal.MapIndex(reflect.ValueOf(key)).Interface()
-		}
+	if len(dataValKeysUnused) > 0 {
+		if remainField != nil {
+			// Build a map of only the unused values
+			remain := map[interface{}]interface{}{}
+			for key := range dataValKeysUnused {
+				remain[key] = dataVal.MapIndex(reflect.ValueOf(key)).Interface()
+			}
 
-		// Decode it as-if we were just decoding this map onto our map.
-		if err := d.decodeMap(name, remain, remainField.val); err != nil {
-			errors = append(errors, err)
+			// Decode it as-if we were just decoding this map onto our map.
+			if err := d.decodeMap(name, remain, remainField.val); err != nil {
+				errors = append(errors, err)
+			}
+		} else if d.NoRemainFields {
+			errors = append(errors, fmt.Errorf("no remain field for unused keys: %v", dataValKeysUnused))
 		}
 	}
 

--- a/decode.go
+++ b/decode.go
@@ -551,6 +551,10 @@ func (d *Decoder) decodeMapFromStruct(name string, dataVal, val, valMap reflect.
 				continue
 			}
 
+			if d.OmitNilPtr && v.Kind() == reflect.Ptr && isEmptyValue(v) {
+				continue
+			}
+
 			// If "squash" is specified in the tag, we squash the field down.
 			squash = squash || strings.Contains(tagValue[index+1:], "squash")
 			if squash {

--- a/decode_test.go
+++ b/decode_test.go
@@ -29,7 +29,7 @@ func TestDecoder_Decode(t *testing.T) {
 		name    string
 		fields  fields
 		args    args
-		wantErr bool
+		wantErr error
 		want    interface{}
 	}{
 		{
@@ -42,7 +42,7 @@ func TestDecoder_Decode(t *testing.T) {
 					Test string `struct:"test"`
 				}{},
 			},
-			wantErr: false,
+			wantErr: nil,
 			want: &struct {
 				Test string `struct:"test"`
 			}{
@@ -94,7 +94,7 @@ func TestDecoder_Decode(t *testing.T) {
 					Time    time.Time `struct:"time"`
 				}{},
 			},
-			wantErr: false,
+			wantErr: nil,
 			want: &struct {
 				String  string    `struct:"string"`
 				Bool    bool      `struct:"bool"`
@@ -145,7 +145,7 @@ func TestDecoder_Decode(t *testing.T) {
 					} `struct:"test"`
 				}{},
 			},
-			wantErr: false,
+			wantErr: nil,
 			want: &struct {
 				Test *struct {
 					Abc string `struct:"abc"`
@@ -175,7 +175,7 @@ func TestDecoder_Decode(t *testing.T) {
 					Test string `struct:"test"`
 				}{},
 			},
-			wantErr: false,
+			wantErr: nil,
 			want: &struct {
 				Test string `struct:"test"`
 			}{
@@ -195,7 +195,7 @@ func TestDecoder_Decode(t *testing.T) {
 					Test string `struct:"test-x"`
 				}{},
 			},
-			wantErr: false,
+			wantErr: nil,
 			want: &struct {
 				Test string `struct:"test-x"`
 			}{
@@ -215,7 +215,7 @@ func TestDecoder_Decode(t *testing.T) {
 					Test string `struct:"test X"`
 				}{},
 			},
-			wantErr: false,
+			wantErr: nil,
 			want: &struct {
 				Test string `struct:"test X"`
 			}{
@@ -257,7 +257,7 @@ func TestDecoder_Decode(t *testing.T) {
 					TestY time.Duration `struct:"test_y"`
 				}{},
 			},
-			wantErr: false,
+			wantErr: nil,
 			want: &struct {
 				Test  time.Duration `struct:"test X"`
 				TestY time.Duration `struct:"test_y"`
@@ -272,7 +272,7 @@ func TestDecoder_Decode(t *testing.T) {
 				input:  append(make([]byte, 0, 100), []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}...),
 				output: func() interface{} { v := make([]byte, 0, 10); return &v }(),
 			},
-			wantErr: false,
+			wantErr: nil,
 			want:    func() interface{} { v := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}; return &v }(),
 		},
 	}
@@ -290,7 +290,7 @@ func TestDecoder_Decode(t *testing.T) {
 				WeaklyDashUnderscore:  tt.fields.WeaklyDashUnderscore,
 				WeaklyIgnoreSeperator: tt.fields.WeaklyIgnoreSeperator,
 			}
-			if err := d.Decode(tt.args.input, tt.args.output); (err != nil) != tt.wantErr {
+			if err := d.Decode(tt.args.input, tt.args.output); !reflect.DeepEqual(err, tt.wantErr) {
 				t.Errorf("Decoder.Decode() error = %v, wantErr %v", err, tt.wantErr)
 
 				return

--- a/decoder.go
+++ b/decoder.go
@@ -67,6 +67,9 @@ type Decoder struct {
 
 	// ForcePtr2 assume `struct:",ptr2` on all pointer struct fields.
 	ForcePtr2 bool
+
+	// OmitNullPtr omits nil pointers, in the map.
+	OmitNilPtr bool
 }
 
 func (d *Decoder) SetTagName(t string) *Decoder {

--- a/decoder.go
+++ b/decoder.go
@@ -64,6 +64,9 @@ type Decoder struct {
 	// WeaklyIgnoreSeperator ignore seperator on map to struct. variable_name == variablename
 	// values are -, _ and space.
 	WeaklyIgnoreSeperator bool
+
+	// ForcePtr2 assume `struct:",ptr2` on all pointer struct fields.
+	ForcePtr2 bool
 }
 
 func (d *Decoder) SetTagName(t string) *Decoder {

--- a/decoder.go
+++ b/decoder.go
@@ -73,6 +73,9 @@ type Decoder struct {
 
 	// OutputCamelCase will convert map keys to camel case.
 	OuputCamelCase bool
+
+	// NoRemainFields will fail if there are extra fields in the input, that are not in the output.
+	NoRemainFields bool
 }
 
 func (d *Decoder) SetTagName(t string) *Decoder {

--- a/decoder.go
+++ b/decoder.go
@@ -70,6 +70,9 @@ type Decoder struct {
 
 	// OmitNullPtr omits nil pointers, in the map.
 	OmitNilPtr bool
+
+	// OutputCamelCase will convert map keys to camel case.
+	OuputCamelCase bool
 }
 
 func (d *Decoder) SetTagName(t string) *Decoder {

--- a/map.go
+++ b/map.go
@@ -56,6 +56,10 @@ FIELDS:
 			continue
 		}
 
+		if d.OmitNilPtr && val.Kind() == reflect.Ptr && val.IsNil() {
+			continue
+		}
+
 		if tagOpts.Has("string") {
 			s, ok := val.Interface().(fmt.Stringer)
 			if ok {

--- a/map.go
+++ b/map.go
@@ -65,10 +65,7 @@ FIELDS:
 			continue
 		}
 
-		ptr2 := false
-		if tagOpts.Has("ptr2") {
-			ptr2 = true
-		}
+		ptr2 := d.ForcePtr2 || tagOpts.Has("ptr2")
 
 		// custom hooks
 		for _, hook := range d.Hooks {

--- a/map.go
+++ b/map.go
@@ -3,6 +3,7 @@ package struct2
 import (
 	"fmt"
 	"reflect"
+	"strings"
 )
 
 type configMap struct {
@@ -41,8 +42,11 @@ FIELDS:
 	for _, field := range fields {
 		name := field.Name
 		val := v.FieldByName(name)
-		isSubStruct := false
+		if d.OuputCamelCase {
+			name = strings.ToLower(name[0:1]) + name[1:]
+		}
 
+		isSubStruct := false
 		var finalVal interface{}
 
 		tagName, tagOpts := d.parseTag(field)

--- a/map_test.go
+++ b/map_test.go
@@ -206,6 +206,50 @@ func TestDecoder_Map(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "ouput with OuputCamelCase",
+			decoder: Decoder{
+				OuputCamelCase: true,
+			},
+			args: args{
+				s: struct {
+					Name     string
+					Name2    string `struct:"Name2"`
+					Train    Train
+					TrainPtr *Train
+					Trains   []Train
+				}{
+					Name:  "abc",
+					Name2: "def",
+					Train: Train{
+						Wagon: int2Ptr(5),
+					},
+					TrainPtr: &Train{
+						Wagon: int2Ptr(5),
+					},
+					Trains: []Train{
+						{
+							Wagon: int2Ptr(5),
+						},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"name":  "abc",
+				"Name2": "def",
+				"train": map[string]interface{}{
+					"wagon": 5,
+				},
+				"trainPtr": map[string]interface{}{
+					"wagon": 5,
+				},
+				"trains": []interface{}{
+					map[string]interface{}{
+						"wagon": 5,
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/map_test.go
+++ b/map_test.go
@@ -17,6 +17,9 @@ func TestDecoder_Map(t *testing.T) {
 	type Train struct {
 		Wagon *int `struct:"wagon,ptr2"`
 	}
+	type TrainNoPtr2 struct {
+		Wagon *int `struct:"wagon"`
+	}
 
 	train := Train{
 		Wagon: int2Ptr(5),
@@ -150,6 +153,28 @@ func TestDecoder_Map(t *testing.T) {
 				"name":  "abc",
 				"ptr":   "pointer",
 				"train": []interface{}{map[string]interface{}{"wagon": 5}},
+			},
+		},
+		{
+			name:    "pointer with ForcePtr2",
+			decoder: Decoder{ForcePtr2: true},
+			args: args{
+				s: struct {
+					Name  string      `struct:"name"`
+					Ptr   *string     `struct:"ptr"`
+					Train TrainNoPtr2 `struct:"train"`
+				}{
+					Name:  "abc",
+					Ptr:   str2Ptr("pointer"),
+					Train: TrainNoPtr2{},
+				},
+			},
+			want: map[string]interface{}{
+				"name": "abc",
+				"ptr":  "pointer",
+				"train": map[string]interface{}{
+					"wagon": 0,
+				},
 			},
 		},
 	}

--- a/map_test.go
+++ b/map_test.go
@@ -177,6 +177,35 @@ func TestDecoder_Map(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "pointer with OmitNilPtr",
+			decoder: Decoder{OmitNilPtr: true},
+			args: args{
+				s: struct {
+					Name     string   `struct:"name"`
+					Ptr      *string  `struct:"ptr,ptr2"`
+					Train    Train    `struct:"train"`
+					TrainPtr *Train   `struct:"trainPtr"`
+					Trains   *[]Train `struct:"trains"`
+				}{
+					Name:     "abc",
+					Ptr:      nil,
+					Train:    Train{},
+					TrainPtr: &Train{},
+					Trains: &[]Train{
+						{},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"name":     "abc",
+				"train":    map[string]interface{}{},
+				"trainPtr": map[string]interface{}{},
+				"trains": []interface{}{
+					map[string]interface{}{},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Greetings,
I am late, sorry about that. 
Added some missing explanation for `remain` struct tag.
Added some `Decoder` options, that will make library usable with completely not tagged Go structs fields.

Closes #8. Closes #11.