### PR TITLE
Fix: support more string tag casting

### DIFF
--- a/cast.go
+++ b/cast.go
@@ -1,0 +1,62 @@
+package struct2
+
+import (
+	"fmt"
+	"html/template"
+	"strconv"
+)
+
+// ToStringE casts an interface to a string type.
+// Taken from github.com/spf13/cast. All rights reserved.
+func ToStringE(i interface{}) (string, error) {
+	switch s := i.(type) {
+	case string:
+		return s, nil
+	case bool:
+		return strconv.FormatBool(s), nil
+	case float64:
+		return strconv.FormatFloat(s, 'f', -1, 64), nil
+	case float32:
+		return strconv.FormatFloat(float64(s), 'f', -1, 32), nil
+	case int:
+		return strconv.Itoa(s), nil
+	case int64:
+		return strconv.FormatInt(s, 10), nil
+	case int32:
+		return strconv.Itoa(int(s)), nil
+	case int16:
+		return strconv.FormatInt(int64(s), 10), nil
+	case int8:
+		return strconv.FormatInt(int64(s), 10), nil
+	case uint:
+		return strconv.FormatUint(uint64(s), 10), nil
+	case uint64:
+		return strconv.FormatUint(uint64(s), 10), nil
+	case uint32:
+		return strconv.FormatUint(uint64(s), 10), nil
+	case uint16:
+		return strconv.FormatUint(uint64(s), 10), nil
+	case uint8:
+		return strconv.FormatUint(uint64(s), 10), nil
+	case []byte:
+		return string(s), nil
+	case template.HTML:
+		return string(s), nil
+	case template.URL:
+		return string(s), nil
+	case template.JS:
+		return string(s), nil
+	case template.CSS:
+		return string(s), nil
+	case template.HTMLAttr:
+		return string(s), nil
+	case nil:
+		return "", nil
+	case fmt.Stringer:
+		return s.String(), nil
+	case error:
+		return s.Error(), nil
+	default:
+		return "", fmt.Errorf("unable to cast %#v of type %T to string", i, i)
+	}
+}

--- a/cast.go
+++ b/cast.go
@@ -3,15 +3,19 @@ package struct2
 import (
 	"fmt"
 	"html/template"
+	"reflect"
 	"strconv"
 )
 
 // ToStringE casts an interface to a string type.
 // Taken from github.com/spf13/cast. All rights reserved.
 func ToStringE(i interface{}) (string, error) {
+	i = indirectToStringerOrError(i)
 	switch s := i.(type) {
 	case string:
 		return s, nil
+	case fmt.Stringer:
+		return s.String(), nil
 	case bool:
 		return strconv.FormatBool(s), nil
 	case float64:
@@ -52,11 +56,29 @@ func ToStringE(i interface{}) (string, error) {
 		return string(s), nil
 	case nil:
 		return "", nil
-	case fmt.Stringer:
-		return s.String(), nil
 	case error:
 		return s.Error(), nil
 	default:
 		return "", fmt.Errorf("unable to cast %#v of type %T to string", i, i)
 	}
+}
+
+// From html/template/content.go
+// Copyright 2011 The Go Authors. All rights reserved.
+// indirectToStringerOrError returns the value, after dereferencing as many times
+// as necessary to reach the base type (or nil) or an implementation of fmt.Stringer
+// or error,
+func indirectToStringerOrError(a interface{}) interface{} {
+	if a == nil {
+		return nil
+	}
+
+	errorType := reflect.TypeOf((*error)(nil)).Elem()
+	fmtStringerType := reflect.TypeOf((*fmt.Stringer)(nil)).Elem()
+
+	v := reflect.ValueOf(a)
+	for !v.Type().Implements(fmtStringerType) && !v.Type().Implements(errorType) && v.Kind() == reflect.Ptr && !v.IsNil() {
+		v = v.Elem()
+	}
+	return v.Interface()
 }

--- a/map.go
+++ b/map.go
@@ -1,7 +1,6 @@
 package struct2
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 )
@@ -32,7 +31,7 @@ func (d *Decoder) convertMap(input interface{}, config configMap) map[string]int
 
 	out := make(map[string]interface{})
 
-	fields := []reflect.StructField{}
+	var fields []reflect.StructField
 
 	d.getFields(v, func(sf reflect.StructField) {
 		fields = append(fields, sf)
@@ -65,11 +64,11 @@ FIELDS:
 		}
 
 		if tagOpts.Has("string") {
-			s, ok := val.Interface().(fmt.Stringer)
-			if ok {
-				out[name] = s.String()
+			s, err := ToStringE(val.Interface())
+			if err != nil {
+				continue
 			}
-
+			out[name] = s
 			continue
 		}
 

--- a/map_test.go
+++ b/map_test.go
@@ -5,6 +5,12 @@ import (
 	"testing"
 )
 
+type stringerValue int
+
+func (s stringerValue) String() string {
+	return "stringerValue"
+}
+
 func str2Ptr(s string) *string {
 	return &s
 }
@@ -19,6 +25,11 @@ func TestDecoder_Map(t *testing.T) {
 	}
 	type TrainNoPtr2 struct {
 		Wagon *int `struct:"wagon"`
+	}
+
+	type TrainStringTags struct {
+		Wagon    *int          `struct:"wagon,string"`
+		Stringer stringerValue `struct:"stringer,string"`
 	}
 
 	train := Train{
@@ -247,6 +258,25 @@ func TestDecoder_Map(t *testing.T) {
 					map[string]interface{}{
 						"wagon": 5,
 					},
+				},
+			},
+		},
+		{
+			name: "string tags",
+			args: args{
+				s: struct {
+					Train TrainStringTags `struct:"train"`
+				}{
+					Train: TrainStringTags{
+						Wagon:    int2Ptr(5),
+						Stringer: 1,
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"train": map[string]interface{}{
+					"wagon":    "5",
+					"stringer": "stringerValue",
 				},
 			},
 		},


### PR DESCRIPTION
we noticed that when we have in some structs (GCP in this case) that if we have a `string` tag the casting will only check if it's a stringer. 

Added support to more types. Code was copied from spf13/cast, and should keep also original intent.

Will add tests in next commit

@rytsh 